### PR TITLE
Fix: Apply wallpaper to all desktops including the current one

### DIFF
--- a/experimental/SyncVirtualDesktops.ps1
+++ b/experimental/SyncVirtualDesktops.ps1
@@ -18,7 +18,7 @@ if (-Not (Get-Module -ListAvailable -Name VirtualDesktop)) {
 
 Get-DesktopList | ForEach-Object {
     if (-Not (Test-CurrentDesktop -Desktop $_.Number)) {
-        Set-DesktopWallpaper -Desktop $_.Number -Path $params.imagePaths[0]
+        Set-DesktopWallpaper -Desktop $_.Number -Path $params.imagePaths
     }
 }
 


### PR DESCRIPTION
This change ensures that the Set-DesktopWallpaper command correctly applies the wallpaper to all virtual desktops, including the current one, by removing the incorrect index reference from the $params.imagePaths array.