### PR TITLE
Added brightness control script with a check for the executable required

### DIFF
--- a/stable/ChangeMonitorBrightness.ps1
+++ b/stable/ChangeMonitorBrightness.ps1
@@ -1,0 +1,28 @@
+# NOTE: Requires hardware that supports DDC/CI (the ability to change display brightness in Windows)
+$params = $Input | ConvertFrom-Json
+
+# Edit these values to be a valid screen brightness percent between 0 and 100
+$sunriseBrightness = 40
+$dayBrightness = 80
+$sunsetBrightness = 30
+$nightBrightness = 20
+
+if ($params.daySegment4 -Eq -1) {
+    $params.daySegment4 = $params.daySegment2 * 2 + 1
+}
+
+$brightnessPercent = switch ($params.daySegment4) {
+    0 { $sunriseBrightness }
+    1 { $dayBrightness }
+    2 { $sunsetBrightness }
+    3 { $nightBrightness }
+}
+
+$ddc_app = '.\ddccli.exe'
+
+# Checks if the required DCC utility is present, if not then downloads it from the source.
+if (-Not (Test-Path -Path $ddc_app)) {
+    Invoke-WebRequest -Uri 'https://github.com/hensm/ddccli/releases/download/v0.0.2/ddccli.exe' -OutFile $ddc_app
+}
+
+Start-Process -FilePath $ddc_app -ArgumentList "-b $brightnessPercent" -NoNewWindow


### PR DESCRIPTION
Update to the previous monitor brightness control script by @1NFERR from 3 years ago and updated it with the latest param configuration and a check for the extra `ddccli.exe`, and a different name.

Limitations (that I would like to improve):
- Brightness changes suddenly [maybe there is a way to do that over a period for smooth transition]
- When manually turning off the monitor and on again the brightness setting does not persist [maybe it's specific to my (old) monitor, can't verify]